### PR TITLE
fix: remove dividers on detached

### DIFF
--- a/src/split-pane-divider.ts
+++ b/src/split-pane-divider.ts
@@ -25,7 +25,7 @@ export class SplitPaneDivider implements ComponentBind, ComponentDetached {
     private previousSiblingSize = 0;
     private nextSiblingSize = 0;
 
-    private readonly element: Element;
+    public readonly element: Element;
     private readonly events: EventAggregator;
 
     constructor(element: any, events: EventAggregator) {

--- a/src/split-pane.ts
+++ b/src/split-pane.ts
@@ -51,6 +51,7 @@ export class SplitPane implements ComponentAttached, ComponentDetached, Componen
     detached(): void {
         for (let divider of this.dividers) {
             divider.detached();
+            divider.element.remove();
         }
     }
 


### PR DESCRIPTION
Not doing so produces new dividers each time aurelia reuses the cached DOM fragment